### PR TITLE
Fix non null assertion operator

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchFragment.kt
@@ -20,10 +20,10 @@ class SearchFragment : Fragment(R.layout.fragment_search) {
         super.onViewCreated(view, savedInstanceState)
 
         val fragmentSearchBinding = FragmentSearchBinding.bind(view)
-        val searchViewModel = SearchViewModel(context!!)
-        val linearLayoutManager = LinearLayoutManager(context!!)
+        val searchViewModel = SearchViewModel(requireContext())
+        val linearLayoutManager = LinearLayoutManager(requireContext())
         val dividerItemDecoration =
-            DividerItemDecoration(context!!, linearLayoutManager.orientation)
+            DividerItemDecoration(requireContext(), linearLayoutManager.orientation)
         val customAdapter = CustomAdapter(
             object : CustomAdapter.OnItemClickListener {
                 override fun itemClick(item: Item) {
@@ -36,7 +36,7 @@ class SearchFragment : Fragment(R.layout.fragment_search) {
             if (action != EditorInfo.IME_ACTION_SEARCH) {
                 return@setOnEditorActionListener false
             }
-            
+
             editText.text.toString().let {
                 searchViewModel.getSearchResults(it).apply {
                     customAdapter.submitList(this)

--- a/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchViewModel.kt
@@ -27,6 +27,7 @@ class SearchViewModel(val context: Context) : ViewModel() {
         val client = HttpClient(Android)
 
         return@runBlocking GlobalScope.async {
+
             val response: HttpResponse =
                 client?.get("https://api.github.com/search/repositories") {
                     header("Accept", "application/vnd.github.v3+json")

--- a/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchViewModel.kt
@@ -41,7 +41,8 @@ class SearchViewModel(val context: Context) : ViewModel() {
             for (i in 0 until jsonItems.length()) {
                 val jsonItem = jsonItems.optJSONObject(i) ?: break
                 val name = jsonItem.optString("full_name")
-                val ownerIconUrl = jsonItem.optJSONObject("owner")!!.optString("avatar_url")
+                val ownerIconUrl =
+                    jsonItem.optJSONObject("owner")?.optString("avatar_url") ?: continue
                 val language = jsonItem.optString("language")
                 val stargazersCount = jsonItem.optLong("stargazers_count")
                 val watchersCount = jsonItem.optLong("watchers_count")

--- a/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchViewModel.kt
@@ -35,7 +35,7 @@ class SearchViewModel(val context: Context) : ViewModel() {
                 }
 
             val jsonBody = JSONObject(response.receive<String>())
-            val jsonItems = jsonBody.optJSONArray("items")!!
+            val jsonItems = jsonBody.optJSONArray("items") ?: return@async listOf()
             val items = mutableListOf<Item>()
 
             for (i in 0 until jsonItems.length()) {

--- a/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchViewModel.kt
@@ -39,7 +39,7 @@ class SearchViewModel(val context: Context) : ViewModel() {
             val items = mutableListOf<Item>()
 
             for (i in 0 until jsonItems.length()) {
-                val jsonItem = jsonItems.optJSONObject(i)!!
+                val jsonItem = jsonItems.optJSONObject(i) ?: break
                 val name = jsonItem.optString("full_name")
                 val ownerIconUrl = jsonItem.optJSONObject("owner")!!.optString("avatar_url")
                 val language = jsonItem.optString("language")


### PR DESCRIPTION
## チケットへのリンク

* #2
* 非null表明演算子の削減

## やったこと

* context!!をrequireContext()に変更
* optJSONArrayがnullのとき、結果として空のリストを返すようにした
* 指定されたインデックスを持つoptJSONObjectが存在しない場合にループを抜けるようにした。このループはJSONからデータを取り出すためのものである
* JSON内のownerが存在しない場合、そのループをスキップするようにした

## やらないこと

* searchResultFragment.kt内においてbindingのゲッターが_bindingの値を使用する際に非null表明演算子を使用しているが、対処法が思いつかなかったため、今回は変更しない

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

* エミュレータ( Pixel4 API30 Android 11.0 )上にて、検索フィールドに文字入力および検索結果が出ることを確認。

## 備考

* jsonItems.length()で最大インデックスの最大値を決めているため、あるインデックスを持つJSONObjectが存在するかの判定はいらないかもしれないです。十分な知識がなく判断がつかないため、コミットは残しておきます。
