### PR TITLE
可読性の向上：strings.xml内で文字列を定義

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchResultFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchResultFragment.kt
@@ -20,9 +20,6 @@ class SearchResultFragment : Fragment(R.layout.fragment_search_result) {
     private var _binding: FragmentSearchResultBinding? = null
     private val binding get() = _binding!!
 
-    //private val viewModel: SearchViewModel by viewModels()
-
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -34,9 +31,9 @@ class SearchResultFragment : Fragment(R.layout.fragment_search_result) {
         binding.ownerIconView.load(item.ownerIconUrl)
         binding.nameView.text = item.name
         binding.languageView.text = item.language
-        binding.starsView.text = "${item.stargazersCount} stars"
-        binding.watchersView.text = "${item.watchersCount} watchers"
-        binding.forksView.text = "${item.forksCount} forks"
-        binding.openIssuesView.text = "${item.openIssuesCount} open issues"
+        binding.starsView.text = getString(R.string.stars_text, item.stargazersCount)
+        binding.watchersView.text = getString(R.string.watchers_text, item.watchersCount)
+        binding.forksView.text = getString(R.string.forks_text, item.forksCount)
+        binding.openIssuesView.text = getString(R.string.open_issues_text, item.openIssuesCount)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,8 @@
     <string name="app_name">Android Engineer CodeCheck</string>
     <string name="searchInputText_hint">GitHub のリポジトリを検索できるよー</string>
     <string name="written_language">Written in %s</string>
+    <string name="stars_text">%1$d stars</string>
+    <string name="watchers_text">%1$d watchers</string>
+    <string name="forks_text">%1$d forks</string>
+    <string name="open_issues_text">%1$d open issues</string>
 </resources>


### PR DESCRIPTION
## チケットへのリンク

* #1 

## やったこと

* SearchResultFragment内で文字列がハードコーディングされていたため、strings.xml内で文字列を定義するようにした

## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

* エミュレータ( Pixel4 API30 Android 11.0 )上にて、検索フィールドに文字入力および検索結果が出ることを確認。
