### PR TITLE
バグの修正：メモリリークへの対処

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchActivity.kt
@@ -4,6 +4,5 @@
 package jp.co.yumemi.android.codeCheck
 
 import androidx.appcompat.app.AppCompatActivity
-import java.util.*
 
 class SearchActivity : AppCompatActivity(R.layout.activity_search)

--- a/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchFragment.kt
@@ -20,7 +20,7 @@ class SearchFragment : Fragment(R.layout.fragment_search) {
         super.onViewCreated(view, savedInstanceState)
 
         val fragmentSearchBinding = FragmentSearchBinding.bind(view)
-        val searchViewModel = SearchViewModel(requireContext())
+        val searchViewModel = SearchViewModel()
         val linearLayoutManager = LinearLayoutManager(requireContext())
         val dividerItemDecoration =
             DividerItemDecoration(requireContext(), linearLayoutManager.orientation)

--- a/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchResultFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchResultFragment.kt
@@ -21,18 +21,17 @@ class SearchResultFragment : Fragment(R.layout.fragment_search_result) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val searchViewModel = SearchViewModel(requireContext())
+        val searchViewModel = SearchViewModel()
         Log.d("検索した日時", searchViewModel.lastSearchDate.toString())
 
         val item = args.item
         _binding = FragmentSearchResultBinding.bind(view)
         binding.ownerIconView.load(item.ownerIconUrl)
         binding.nameView.text = item.name
-        binding.languageView.text = item.language
+        binding.languageView.text = getString(R.string.written_language, item.language)
         binding.starsView.text = getString(R.string.stars_text, item.stargazersCount)
         binding.watchersView.text = getString(R.string.watchers_text, item.watchersCount)
         binding.forksView.text = getString(R.string.forks_text, item.forksCount)
-        binding.openIssuesView.text = getString(R.string.open_issues_text, item.openIssuesCount)
     }
 
     override fun onDestroy() {

--- a/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchResultFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchResultFragment.kt
@@ -7,11 +7,9 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.navArgs
 import coil.load
 import jp.co.yumemi.android.codeCheck.databinding.FragmentSearchResultBinding
-import java.util.*
 
 class SearchResultFragment : Fragment(R.layout.fragment_search_result) {
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchResultFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchResultFragment.kt
@@ -36,4 +36,9 @@ class SearchResultFragment : Fragment(R.layout.fragment_search_result) {
         binding.forksView.text = getString(R.string.forks_text, item.forksCount)
         binding.openIssuesView.text = getString(R.string.open_issues_text, item.openIssuesCount)
     }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        _binding = null
+    }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchViewModel.kt
@@ -18,7 +18,7 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 import java.util.*
 
-class SearchViewModel() : ViewModel() {
+class SearchViewModel : ViewModel() {
 
     private var _lastSearchDate = Date()
     val lastSearchDate get() = _lastSearchDate

--- a/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchViewModel.kt
@@ -18,7 +18,7 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 import java.util.*
 
-class SearchViewModel(val context: Context) : ViewModel() {
+class SearchViewModel() : ViewModel() {
 
     private var _lastSearchDate = Date()
     val lastSearchDate get() = _lastSearchDate
@@ -55,7 +55,7 @@ class SearchViewModel(val context: Context) : ViewModel() {
                     Item(
                         name = name,
                         ownerIconUrl = ownerIconUrl,
-                        language = context.getString(R.string.written_language, language),
+                        language = language,
                         stargazersCount = stargazersCount,
                         watchersCount = watchersCount,
                         forksCount = forksCount,

--- a/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchViewModel.kt
@@ -5,9 +5,6 @@ package jp.co.yumemi.android.codeCheck
 
 import android.content.Context
 import android.os.Parcelable
-import android.util.Log
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import io.ktor.client.*
 import io.ktor.client.call.*


### PR DESCRIPTION
## チケットへのリンク

* #3 

## やったこと

* _bindingのメモリリーク対策
* viewModelでcontextを不使用とすることによるメモリリーク対策

## やらないこと

* View, ViewModelの責務が異なっているので、後ほど修正を行う。

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

* エミュレータ( Pixel4 API30 Android 11.0 )上にて、検索フィールドに文字入力および検索結果が出ることを確認。
