### PR TITLE
可読性の向上：lastSearchDateをデータクラスで保存

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchDateModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchDateModel.kt
@@ -1,0 +1,10 @@
+package jp.co.yumemi.android.codeCheck
+
+import java.util.*
+
+/**
+ * lastSearchDateを保持するModel
+ */
+data class SearchDateModel (
+    val lastSearchDate: Date? = null,
+)

--- a/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchResultFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchResultFragment.kt
@@ -27,7 +27,7 @@ class SearchResultFragment : Fragment(R.layout.fragment_search_result) {
         super.onViewCreated(view, savedInstanceState)
 
         val searchViewModel: SearchViewModel by activityViewModels()
-        Log.d("検索した日時", searchViewModel.lastSearchDate.toString())
+        Log.d("検索した日時", searchViewModel.lastSearchDate)
 
         // viewに表示されるレポジトリの詳細を設定
         val item = args.item

--- a/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codeCheck/SearchViewModel.kt
@@ -11,6 +11,9 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.runBlocking
 import org.json.JSONObject
 import java.util.*
@@ -20,9 +23,11 @@ import java.util.*
  */
 class SearchViewModel : ViewModel() {
 
-    // TODO: lastSearchDateをモデルとして保存、およびlastSearchDateを取得する関数の定義
-    private var _lastSearchDate = Date()
-    val lastSearchDate get() = _lastSearchDate
+    // SearchDateModelからlastSearchDateを取得し、viewに渡せるようにしている
+    private val _searchDateModel = MutableStateFlow(SearchDateModel())
+    private val searchDateModel = _searchDateModel.asStateFlow()
+    val lastSearchDate: String
+        get() = searchDateModel.value.lastSearchDate.toString()
 
     // 検索を行い、レポジトリ名のリストを取得する
     fun getSearchResults(inputText: String): List<Item> = runBlocking {
@@ -69,7 +74,9 @@ class SearchViewModel : ViewModel() {
             }
 
             // 現在時刻を保存
-            _lastSearchDate = Date()
+            _searchDateModel.update { currentState ->
+                currentState.copy(lastSearchDate = Date())
+            }
 
             return@async items.toList()
         }.await()


### PR DESCRIPTION
責務の分離

## チケットへのリンク

* #1 
* #6 

## やったこと

* refactor: lastSearchDateをViewModelから独立させ、データクラスにした

## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

* エミュレータ( Pixel4 API30 Android 11.0 )上にて、検索フィールドに文字入力および検索結果が出ることを確認。